### PR TITLE
Fix Faraday warning about basic_auth deprecation

### DIFF
--- a/lib/togglv8/connection.rb
+++ b/lib/togglv8/connection.rb
@@ -21,7 +21,7 @@ module TogglV8
         faraday.response :logger, Logger.new('faraday.log') if opts[:log]
         faraday.adapter Faraday.default_adapter
         faraday.headers = { "Content-Type" => "application/json" }
-        faraday.basic_auth username, password
+        faraday.request(:basic_auth, username, password)
       end
     end
 


### PR DESCRIPTION
## Context

Faraday has deprecated `Faraday::Connection#basic_auth` and show a warning message when running the code

## Warning message
```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in vers`ion 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

## What does this PR do

Fix warning message by updating related code to the latest version