### PR TITLE
fix api url for reports

### DIFF
--- a/lib/reportsv2.rb
+++ b/lib/reportsv2.rb
@@ -1,5 +1,5 @@
 module TogglV8
-  TOGGL_REPORTS_URL = 'https://toggl.com/reports/api/'
+  TOGGL_REPORTS_URL = 'https://api.track.toggl.com/reports/api/'
 
   class ReportsV2
     include TogglV8::Connection


### PR DESCRIPTION
Update the URL for the reports API. Apparently that needs to be updated as well if you want to retrieve the details in reports.
